### PR TITLE
Changed channel selection to use enum.Flag

### DIFF
--- a/src/jolt/driver/joltcb.py
+++ b/src/jolt/driver/joltcb.py
@@ -301,7 +301,7 @@ class JOLTComputerBoard():
 
     def set_channel(self, channel: Channel) -> None:
         """
-        :param val: Channel: color channel
+        :param channel: Channel: color channel
         :returns: (None)
         """
         if not isinstance(channel, Channel):

--- a/src/jolt/driver/joltcb.py
+++ b/src/jolt/driver/joltcb.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 '''
 
+import enum
 import os
 import serial
 import logging
@@ -79,16 +80,18 @@ CMD_CB_ISP = 0xfe
 CMD_FW_ISP = 0xff
 CMD_PASSTHROUGH_MODE = 0x65
 
-CHANNEL_PAN = 7
-CHANNEL_R = 1
-CHANNEL_G = 4
-CHANNEL_B = 2
-CHANNEL_OFF = 0
-
 SAFERANGE_MPCC_CURRENT = (-5000, 5000)
 SAFERANGE_MPCC_TEMP = (-20, 20)  # °C
 SAFERANGE_HEATSINK_TEMP = (-20, 40)  # °C
 SAFERANGE_VACUUM_PRESSURE = (0, 5)  # mbar
+
+
+class Channel(enum.Flag):
+    NONE = 0
+    RED = 1
+    BLUE = 2
+    GREEN = 4
+    PANCHROMATIC = 7
 
 
 class JOLTError(Exception):
@@ -288,22 +291,22 @@ class JOLTComputerBoard():
         b = self._send_query(CMD_GET_VACUUM_PRESSURE)  # 4 bytes, 10e3 - 12e6
         return int.from_bytes(b, 'little', signed=True) * 1e-3
     
-    def get_channel(self):
+    def get_channel(self) -> Channel:
         """
-        :returns: (CHANNEL_R, CHANNEL_G, CHANNEL_B, CHANNEL_PAN): color channel
+        :returns: Channel: color channel
         """
         b = self._send_query(CMD_GET_CHANNEL)  # 1 byte
-        return int.from_bytes(b, 'little', signed=True)
+        value = int.from_bytes(b, 'little', signed=True)
+        return Channel(value)
 
-    def set_channel(self, val):
+    def set_channel(self, channel: Channel) -> None:
         """
-        :param val: (CHANNEL_R, CHANNEL_G, CHANNEL_B, CHANNEL_PAN): color channel
+        :param val: Channel: color channel
         :returns: (None)
         """
-        if val not in (CHANNEL_R, CHANNEL_G, CHANNEL_B, CHANNEL_PAN):
-            logging.error("Unknown channel %s, needs to be %s, %s, %s, or %s." % (val, CHANNEL_R, CHANNEL_G,
-                                                                                     CHANNEL_B, CHANNEL_PAN))
-        b = val.to_bytes(1, 'little', signed=True)
+        if not isinstance(channel, Channel):
+            logging.error("Unknown channel %s, needs to be of type Channel.", channel)
+        b = channel.value.to_bytes(1, 'little', signed=True)
         self._send_cmd(CMD_SET_CHANNEL, b)
 
     def get_itec(self):
@@ -501,8 +504,7 @@ class JOLTSimulator():
         self.hot_plate_temp = int(35e6)  # µC
         self.output = int(800)  # µV
         self.vacuum_pressure = int(3e3)  # µBar
-        self.channel = CHANNEL_R
-        self.channels = str(CHANNEL_R) + str(CHANNEL_G) + str(CHANNEL_B)
+        self.channel = Channel.RED
         self.itec = int(10e6)
 
         self._temp_thread = None
@@ -629,10 +631,10 @@ class JOLTSimulator():
             self._sendAnswer(self.vacuum_pressure.to_bytes(4, 'little', signed=True))
         elif com == CMD_GET_CHANNEL:
             self._sendStatus(ACK)
-            self._sendAnswer(self.channel.to_bytes(1, 'little', signed=True))
+            self._sendAnswer(self.channel.value.to_bytes(1, 'little', signed=True))
         elif com == CMD_SET_CHANNEL:
             self._sendStatus(ACK)
-            self.channel = int.from_bytes(arg, 'little', signed=True)
+            self.channel = Channel(int.from_bytes(arg, 'little', signed=True))
         elif com == CMD_SET_DIFFERENTIAL_OUTPUT:
             self._sendStatus(ACK)
             # do nothing

--- a/src/jolt/gui/jolt_app.py
+++ b/src/jolt/gui/jolt_app.py
@@ -45,10 +45,20 @@ logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=loggin
 
 POLL_INTERVAL = 1.0  # seconds
 SAVE_CONFIG = True  # save configuration before closing
-STR2CHANNEL = {"R": driver.CHANNEL_R, "G": driver.CHANNEL_G, "B": driver.CHANNEL_B,
-               "Pan": driver.CHANNEL_PAN, "OFF": driver.CHANNEL_OFF}
-CHANNEL2STR = {driver.CHANNEL_R: "R", driver.CHANNEL_G: "G", driver.CHANNEL_B: "B",
-                driver.CHANNEL_PAN: "Pan", driver.CHANNEL_OFF: "OFF"}
+STR2CHANNEL = {
+    "R": driver.Channel.RED,
+    "G": driver.Channel.GREEN,
+    "B": driver.Channel.BLUE,
+    "Pan": driver.Channel.PANCHROMATIC,
+    "OFF": driver.Channel.NONE,
+}
+CHANNEL2STR = {
+    driver.Channel.RED: "R",
+    driver.Channel.GREEN: "G",
+    driver.Channel.BLUE: "B",
+    driver.Channel.PANCHROMATIC: "Pan",
+    driver.Channel.NONE: "OFF",
+}
 
 MPPC_TEMP_POWER_OFF = 24  # degrees in °C
 MPPC_TEMP_DEBUG = 15   # degrees in °C
@@ -669,7 +679,7 @@ class JoltApp(wx.App):
         # Modify controls to show hardware values
         ch2sel = {"R": 0, "G": 1, "B": 2, "Pan": 3}
         try:
-            self.channel_ctrl.SetSelection(ch2sel[self.channel])  # fails if it's CHANNEL_OFF
+            self.channel_ctrl.SetSelection(ch2sel[self.channel])  # fails if it's Channel.NONE
         except:
             pass
         self.slider_gain.SetValue(self.gain)


### PR DESCRIPTION
Now uses enum.Flag instead of a set of globals to improve readability.