### PR TITLE
[fix] frontend voltage is 10 bits, so maximum 1023

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ SAFERANGE settings only accept *integer* values.
 If DEFAULT/ambient is set to `True`, then the target mppc_temp is automatically set to
 15°C and no check is done on the pressure.
 The DEFAULT section also accepts a front_offset option, which, if set, changes the
-front-end offset voltage. It accepts values between 0 and 4095. The default value
+front-end offset voltage. It accepts values between 0 and 1023. The default value
 is automatically calibrated at initialization, and is in most cases correct.
 
 When SIGNAL/differential is set to `True`, the analog output of the JOLT,

--- a/src/jolt/driver/joltcb.py
+++ b/src/jolt/driver/joltcb.py
@@ -235,26 +235,26 @@ class JOLTComputerBoard():
 
     def get_frontend_offset(self):
         """
-        :returns: (0 <= int <= 4095) Offset voltage on frontend board
+        :returns: (0 <= int <= 1023) Offset voltage on frontend board
         """
         # The command returns a uint32
-        # Offset is between 0 and 4095 (10 bits)
+        # Offset is between 0 and 1023 (10 bits)
         b = self._send_query(CMD_GET_VOS_ADJ_SETTING)  # 4 bytes
         offset = int.from_bytes(b, 'little', signed=False)
         return offset
 
     def set_frontend_offset(self, val):
         """
-        :param val: (0 <= int <= 4095) Offset voltage on frontend board
+        :param val: (0 <= int <= 1023) Offset voltage on frontend board
         :returns: (None)
         """
-        if not (0 <= val <= 4095):
-            raise ValueError(f"Frontend offset voltage should be between 0 and 4095, got {val}")
+        if not (0 <= val <= 1023):
+            raise ValueError(f"Frontend offset voltage should be between 0 and 1023, got {val}")
         # The command takes a uint32
-        # Offset is between 0 and 4095 (10 bits)
+        # Offset is between 0 and 1023 (10 bits)
         b = int(val).to_bytes(4, 'little', signed=False)
         self._send_cmd(CMD_SET_VOS_ADJ_SETTING, b)
-    
+
     def get_mppc_temp(self):
         """
         :returns: (-20 <= float <= 70): temperature in C


### PR DESCRIPTION
The comments were correctly saying it's 10 bits... but incorrectly translating it as maximum 4095. That's actually 1023.

It doesn't have much effect on the software behaviour, as if the user passed a value > 1023, the device would just complain, and the command would fail pretty much the same way as with detecting it in Python.