### PR TITLE
Jolt V2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 *.aux
 *.pdf
 *.synctex.gz
+.vscode/
+*.feo.tsv
+*.egg-info/
+build

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ On Ubuntu, Python is already installed, so all that is needed is:
 On Windows, get the miniconda installer from there: https://docs.conda.io/en/latest/miniconda.html .
 Then install miniconda, and run an anaconda terminal, go to the folder containing these sources. Then type:
 
-        conda create -y --name jolt python==3.6.13
+        conda create -y --name jolt python==3.6.8
         conda activate jolt
         pip install -r requirements.txt
+
+Note that based on operating system or environment (production or development), one can alter the requirements file.
+There are comments in the file on which sections to (un)comment.
 
 You might also need to install the driver for the FTDI USB to Serial adpater.
 It can be found here: https://ftdichip.com/drivers/d2xx-drivers/ .
@@ -57,6 +60,10 @@ or invalid inputs are inserted, the code updates the variables with some default
    [SIGNAL]
    differential = False
    rgb_filter = True
+
+   [CALIBRATION]
+   calibration_temps = (20, 15)
+   calibration_voltage_range = (30, 37, 1)
 ```
 
 The SAFERANGE variables represent the lower and upper threshold value of the

--- a/doc/developer-doc.tex
+++ b/doc/developer-doc.tex
@@ -99,17 +99,28 @@ For distribution, we package the source code into an .exe file with \texttt{pyin
 This needs to be done on a computer with the operating system that the executable should eventually be executed in.
 
 Currently, to support Windows 10 and Windows 7, the build has to be done on an old Windows 7 64 bits.
-The installation can be performed in a virtual machine.
+The installation can be performed in a virtual machine (although very slow).
 These are the steps:
 \begin{enumerate}
 	\item Install the Windows operating system in a virtual machine, e.g. VirtualBox.
 	\item Install git for Windows (from \texttt{https://gitforwindows.org/}).
 	\item Clone the Jolt repository from: \texttt{https://github.com/delmic/jolt-control.git}
-	\item Install Miniconda 64 bits. For Windows 7, it should be using Python 3.7 or 3.8, before 2022. They can be found here: \texttt{https://repo.anaconda.com/miniconda/}
-	\item Create a "jolt" environment with Python 3.6: \texttt{conda create -y --name jolt python==3.6.13}
+	\item If interested in development work, switch branch via \texttt{git checkout \textit{branch\_name}}.
+	\item Install Miniconda 64 bits. It can be found here: \texttt{https://repo.anaconda.com/miniconda/}
+	\item Create a "jolt" environment with Python 3.6: \texttt{conda create -y --name jolt python==3.6.8}
 	\item Switch to that new environment: \texttt{conda activate jolt}
 	\item Add the extra "forge" channel (for timeout-decorator): \texttt{conda config --append channels conda-forge}
-	\item Install the dependencies: \texttt{conda install --name jolt --file requirements.txt}. (Note that on Linux, you need to remove the pywin32* dependencies.)
+	\item Install the dependencies: \texttt{conda install --name jolt --file requirements.txt}. (Note that depending on operating system and environment, certain sections should be (un)commented)
+\end{enumerate}
+
+\subsection{Running Scripts}
+\begin{enumerate}
+	\item Start a Miniconda terminal.
+	\item Activate the environment: \texttt{conda activate jolt}
+	\item Navigate to the \texttt{jolt-control/install/windows} directory.
+	\item Run "build\_jolt" and select which .exe you want to build (jolt, firmware-updater, or both).
+	\item The executable can be found in the \texttt{dist} folder.
+	\item Sign digitally both executables, with \texttt{signtool}: \texttt{signtool sign /fd SHA256 /t http://timestamp.digicert.com }\emph{PATH-TO-EXECUTABLE.exe}
 \end{enumerate}
 
 \subsection{Building Windows Executables}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,14 @@ decorator
 pyserial<4.0
 click<=8.0
 appdirs
-# needed by appdirs, on Windows
+
+# Windows (comment out if on Linux)
 pywin32
 pyinstaller==4.2
-# needed by pyinstaller, on Windows
-pywin32-ctypes
+pywin32-ctypes  # needed by pyinstaller, on Windows
+
+setuptools>=39.2.0
+
+# Development (uncomment if needed)
+# pandas
+# matplotlib

--- a/scripts/calibration_inspection.py
+++ b/scripts/calibration_inspection.py
@@ -1,0 +1,40 @@
+"""
+Script to inspect the voltage vs. optimal offset characteristic of a calibration run.
+
+Created on 12 March 2025
+@author: Tim Moerkerken
+Copyright © 2025 Tim Moerkerken, Delmic
+"""
+
+# %%
+import matplotlib.pyplot as plt
+from pathlib import Path
+import pandas as pd
+from appdirs import AppDirs
+plt.style.use('default')  # Or 'dark_background'
+
+# %%
+
+dirs = AppDirs("Jolt", "Delmic")
+data_dir = Path(dirs.user_data_dir)
+
+calibration_files = sorted(list(data_dir.glob("jolt-calibration-000000000268513344944902274611242003*.tsv")))
+calibration_file = calibration_files[-1]
+measurement = pd.read_csv(calibration_file, delimiter='\t')
+# %%
+
+for temp in measurement["temperature_target"].unique():
+    plt.figure(figsize=(8, 8))
+    for channel in ["RED", "GREEN", "BLUE", "PANCHROMATIC"]:
+        color = channel.lower() if "PAN" not in channel else "black"
+        cond1 = measurement["channel"] == channel
+        cond2 = measurement["temperature_target"] == temp
+        m = measurement[cond1 & cond2]
+        plt.scatter(m["voltage"].values, m["fe_offset"].values, color=color, label=channel)
+        plt.xlabel("Operating voltage (V)")
+        plt.ylabel("Optimal offset")
+        plt.legend(title="Channel")
+        plt.title(f"{temp} C")
+plt.show()
+
+# %%

--- a/scripts/offset_inspection.py
+++ b/scripts/offset_inspection.py
@@ -1,0 +1,34 @@
+"""Script to inspect data for offset vs. output characteristic for varying operating voltage
+
+Created on 12 March 2025
+@author: Tim Moerkerken
+Copyright © 2025 Tim Moerkerken, Delmic
+"""
+
+# %%
+import matplotlib.pyplot as plt
+from pathlib import Path
+import pandas as pd
+plt.style.use('dark_background')
+# %%
+
+measurement_file = Path("offset_output_relation_red_max_gain_30_37_1.feo.tsv")
+
+measurement = pd.read_csv(measurement_file, delimiter='\t')
+for c in measurement["channel"].unique():
+    plt.figure(figsize=(8 ,8), dpi=300)
+    for v in measurement["voltage_target"].unique():
+        v_match = measurement[measurement["voltage_target"] == v][measurement["channel"] == c]
+        offset = v_match["offset"].values
+        if "fe_output_avg" in v_match:
+            output = v_match["fe_output_avg"].values
+        else:
+            output = v_match["fe_output"].values
+
+        plt.plot(offset[1:], output[1:], label=v)
+    plt.xlabel("Offset")
+    plt.ylabel("FE Output (V)")
+    plt.legend(title="Op. Voltage (V)")
+    plt.title(f"Frontend offset vs. averaged output voltage at {measurement['temperature_target'].unique()[0]}°C\nChannel: {c.lower()}, max gain")
+plt.show()
+# %%

--- a/scripts/offset_output_relationship_measurement.py
+++ b/scripts/offset_output_relationship_measurement.py
@@ -1,0 +1,66 @@
+"""
+Script to acquire data for offset vs. output characteristic for varying operating voltage
+
+Created on 12 March 2025
+@author: Tim Moerkerken
+Copyright © 2025 Tim Moerkerken, Delmic
+"""
+
+# %%
+from jolt.driver import JOLTComputerBoard
+from jolt.driver.joltcb import Channel
+from jolt.util.measurement import await_set, await_set_stabilized, average_get
+from jolt.util.array import arange
+import csv
+from datetime import datetime
+import logging
+import time
+logger = logging.getLogger()
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(formatter)
+
+logging.basicConfig(level=logging.DEBUG, handlers=[console_handler])
+dev = JOLTComputerBoard(simulated=False)
+# dev = JoltMeasurementMock()
+# %%
+TARGET_OP_TEMPS = [25]
+TARGET_OP_VOLTAGES = [30, 33.5, 37]
+TARGET_OP_VOLTAGES = [*range(30, 37, 1), 37]
+
+CHANNELS = [Channel.GREEN, Channel.RED, Channel.BLUE, Channel.PANCHROMATIC]
+
+FE_OFFSET_RANGE = (0, 1024)
+FE_OFFSET_STEP = 4
+timestamp = datetime.now().strftime("%Y%m%d_%H%M")
+
+with open(f"offset_output_relation_{timestamp}.feo.tsv", "w", newline="") as file:
+    writer = csv.writer(file, delimiter='\t')
+    writer.writerow(["temperature_target", "channel", "voltage_target", "temp", "voltage", "offset", "fe_output"])
+
+dev.set_gain(64)
+dev.set_offset(0)
+time.sleep(0.5)
+logger.info(f"Gain is {dev.get_gain()}, offset is {dev.get_offset()}")
+for target_op_temp in TARGET_OP_TEMPS:
+    # Verify this stays stable
+    await_set_stabilized(dev.set_target_mppc_temp, dev.get_cold_plate_temp, target_op_temp, 0.2, 1)
+    for channel in CHANNELS:
+        await_set(dev.set_channel, dev.get_channel, channel)
+        for target_op_voltage in TARGET_OP_VOLTAGES:
+            voltage_stabilized = await_set_stabilized(dev.adjust_voltage, dev.get_voltage, target_op_voltage, 0.1, 0)
+            for offset in range(*FE_OFFSET_RANGE, FE_OFFSET_STEP):
+                await_set_stabilized(dev.set_frontend_offset, dev.get_frontend_offset, offset, 0.1, 1, 0.1)
+                time.sleep(0.2)
+                temp = dev.get_cold_plate_temp()
+                voltage = dev.get_voltage()
+                offset = dev.get_frontend_offset()
+                fe_output = dev.get_frontend_output_voltage()
+                measurement = [target_op_temp, channel.name, target_op_voltage, temp, voltage, offset, fe_output]
+                logger.info(measurement)
+                with open(f"offset_output_relation_{timestamp}.feo.tsv", "a", newline="") as file:
+                    writer = csv.writer(file, delimiter='\t')
+                    writer.writerows([measurement])
+
+# %%

--- a/src/jolt/__init__.py
+++ b/src/jolt/__init__.py
@@ -17,8 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 '''
 
-__version__ = "1.2.1-dev"
+__version__ = "1.3.0-dev"
 __fullname__ = "Delmic Jolt Control Software"
 __shortname__ = "Jolt"
-__copyright__ = "Copyright © 2019-2023 Delmic"
-__authors__ = ["Éric Piel", "Philip Winkler", "Anders Muskens", "Victoria Mavrikopoulou"]
+__copyright__ = "Copyright © 2019-2025 Delmic"
+__authors__ = ["Éric Piel", "Philip Winkler", "Anders Muskens", "Victoria Mavrikopoulou", "Tim Moerkerken"]

--- a/src/jolt/driver/test/calibration_test.py
+++ b/src/jolt/driver/test/calibration_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Created on 5 Mar 2025
+
+Copyright © 2025 Tim Moerkerken, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see http://www.gnu.org/licenses/.
+'''
+
+
+import logging
+import os
+import tempfile
+import unittest
+import threading
+import csv
+import time
+from pathlib import Path
+from jolt.driver.joltcb import JOLTComputerBoard, Channel
+from jolt.util import feo_calib
+
+logging.getLogger().setLevel(logging.DEBUG)
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
+
+
+class TestCalibration(unittest.TestCase):
+    """
+    Tests the Jolt computer board driver.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.jolt = JOLTComputerBoard(simulated=TEST_NOHW)
+
+    @classmethod
+    def setUp(cls):
+        cls.tmpdir = tempfile.TemporaryDirectory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.jolt.terminate()
+
+    @classmethod
+    def tearDown(cls):
+        cls.tmpdir.cleanup()
+
+    def test_calibration_abort(self):
+        stop_event = threading.Event()
+        with self.tmpdir as tmpdir:
+            tmp_file = Path(tmpdir) / "calibration.feo.tsv"
+            self.calibration_thread = threading.Thread(
+                target=feo_calib.run,
+                kwargs=dict(
+                    dev=self.jolt,
+                    calibration_file=tmp_file,
+                    stop_event=stop_event,
+                )
+            )
+            self.calibration_thread.start()
+            # Stop the running calibration preemptively.
+            # Assert the creation of the calibration file. Running calibration files are prefixed with _.
+            time.sleep(2)
+            stop_event.set()
+            self.calibration_thread.join()
+            # The final file should not be present
+            self.assertFalse(tmp_file.exists())
+            # Check if the uncompleted file is present
+            tmp_file_running = tmp_file.with_name(f"_{tmp_file.name}")
+            self.assertTrue(tmp_file_running.exists())
+
+    def test_calibration_run(self):
+        completed_event = threading.Event()
+        with self.tmpdir as tmpdir:
+            tmp_file = Path(tmpdir) / "calibration.feo.tsv"
+
+            def _calibrate():
+                feo_calib.run(
+                    dev=self.jolt,
+                    temperatures=[25],
+                    channels=[Channel.GREEN],
+                    voltage_range=(30, 37, 1),
+                    calibration_file=tmp_file,
+                )
+                completed_event.set()
+
+            self.calibration_thread = threading.Thread(target=_calibrate)
+            self.calibration_thread.start()
+
+            # Poll for completion
+            while not completed_event.is_set():
+                time.sleep(1)
+            # Check if the completed calibration file exists
+            self.assertTrue(tmp_file.exists())
+
+            # Now check qualitatively
+            calibration = []
+            with open(tmp_file, "r") as fp:
+                reader = csv.DictReader(fp, delimiter="\t")
+                for row in reader:
+                    calibration.append(row)
+
+            def _ideal_offset(voltage):
+                # Must be in sync with driver simulator function (simulate_frontend_output_voltage)
+                return (-0.002653 * voltage - 0.029203) / -0.0001640
+
+            for i, calibration_entry in enumerate(calibration):
+                # Voltages are increasing since calibration was sorted
+                voltage_target = float(calibration_entry["voltage_target"])
+                fe_offset = int(calibration_entry["fe_offset"])
+                self.assertAlmostEqual(fe_offset, _ideal_offset(voltage_target), delta=5)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/jolt/driver/test/driver_test.py
+++ b/src/jolt/driver/test/driver_test.py
@@ -47,7 +47,12 @@ class TestDriver(unittest.TestCase):
         # Voltage
         self.jolt.set_voltage(20)
         vol = self.jolt.get_voltage()
-        self.assertEqual(vol, 20)
+        self.assertAlmostEqual(vol, 20, places=1)
+
+        # Voltage forced
+        self.jolt.adjust_voltage(20)
+        vol = self.jolt.get_voltage()
+        self.assertAlmostEqual(vol, 20, places=1)
 
         # Gain
         self.jolt.set_gain(50)
@@ -60,9 +65,9 @@ class TestDriver(unittest.TestCase):
         self.assertAlmostEqual(offset, 99, places=1)
 
         # Frontend offset
-        self.jolt.set_frontend_offset(4000)
+        self.jolt.set_frontend_offset(1000)
         offset = self.jolt.get_frontend_offset()
-        self.assertEqual(offset, 4000)
+        self.assertEqual(offset, 1000)
 
 
 if __name__ == "__main__":

--- a/src/jolt/gui/jolt_app.py
+++ b/src/jolt/gui/jolt_app.py
@@ -23,10 +23,12 @@ import configparser
 from jolt import driver
 import jolt
 from jolt.gui import xmlh
-from jolt.util import log, call_in_wx_main
+from jolt.util import log, call_in_wx_main, feo_calib
+from jolt.util.math import argmin, linear_regression
 import logging
 from logging.handlers import RotatingFileHandler
 import os
+from pathlib import Path
 import sys
 import threading
 import time
@@ -36,12 +38,13 @@ from wx import xrc
 import wx
 import wx.adv
 from pkg_resources import resource_filename, resource_stream
+import csv
 
 # Start simulator if environment variable is set
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # Set up logging
-logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.DEBUG)
+logging.basicConfig(format='%(asctime)s %(module)s %(levelname)s %(message)s', level=logging.DEBUG)
 
 POLL_INTERVAL = 1.0  # seconds
 SAVE_CONFIG = True  # save configuration before closing
@@ -61,7 +64,7 @@ CHANNEL2STR = {
 }
 
 MPPC_TEMP_POWER_OFF = 24  # degrees in °C
-MPPC_TEMP_DEBUG = 15   # degrees in °C
+MPPC_TEMP_DEBUG = 25   # degrees in °C
 MPPC_TEMP_POWER_ON = 0  # degrees in °C
 MPPC_TEMP_REL = (-1, 1)  # temperature range, relative to the target temperature, in °C
 
@@ -78,24 +81,25 @@ class JoltApp(wx.App):
         """
         self.simulated = simulated
         self.debug_mode = False
-        self.should_close = threading.Event()  # stop polling thread if set
+        self.should_stop_polling = threading.Event()  # stop polling thread if set
+        self.should_stop_calibration = threading.Event()  # stop calibration thread if set
         self.warnings = set()
         self.error_codes = set()
         self.attrs_to_watch = {}  # empty dict
 
         # Load configuration and logging files, create directories if they don't exist
-        dirs = AppDirs("Jolt", "Delmic")
-        if not os.path.isdir(dirs.user_log_dir):
-            os.makedirs(dirs.user_log_dir)
-        log_file = os.path.join(dirs.user_log_dir, 'jolt.log')  # C:\Users\<name>\AppData\Local\Delmic\Jolt\Logs
+        self.dirs = AppDirs("Jolt", "Delmic")
+        if not os.path.isdir(self.dirs.user_log_dir):
+            os.makedirs(self.dirs.user_log_dir)
+        log_file = os.path.join(self.dirs.user_log_dir, 'jolt.log')  # C:\Users\<name>\AppData\Local\Delmic\Jolt\Logs
         self.init_file_logger(log_file, logging.DEBUG)
 
         logging.info("Software version: %s", jolt.__version__)
         logging.info("Python version: %d.%d", sys.version_info[0], sys.version_info[1])
 
-        self.config_file = os.path.join(dirs.user_data_dir, 'jolt.ini')
-        if not os.path.isdir(dirs.user_data_dir):
-            os.makedirs(dirs.user_data_dir)
+        self.config_file = os.path.join(self.dirs.user_data_dir, 'jolt.ini')
+        if not os.path.isdir(self.dirs.user_data_dir):
+            os.makedirs(self.dirs.user_data_dir)
 
         self.config = None
         # Initialize values
@@ -111,14 +115,17 @@ class JoltApp(wx.App):
         self.mppc_temp_rel, self.saferange_sink_temp, self.saferange_mppc_current, self.saferange_vacuum_pressure = \
             self.load_config(section='SAFERANGE')
         self.differential, self.rgb_filter = self.load_config(section='SIGNAL')
+        self.calibration_file, self.calibration_temps, self.calibration_voltage_range = self.load_config(section='CALIBRATION')
         if not self.rgb_filter:
             # Force the channel to panchromatic. The channel selection will be hidden.
             self.channel = "Pan"
         self.error = 8  # 8 means no error
         self.target_temp = 24
-        self.voltage_gui = self.voltage
+        self.voltage_gui = 0  # Initialize on zero for now
+        self.fe_output = 0
         self.power = False
         self.hv = False
+        self.calibrating = False
 
         # Initialize wx components
         super().__init__(redirect=False)
@@ -131,11 +138,19 @@ class JoltApp(wx.App):
         except IOError as ex:
             self.startup_error = True
             super().__init__(self)
-            dlg = wx.MessageBox("Connection to Jolt failed. Make sure the hardware is connected and turned on.",
-                          'Info', wx.OK)
-            logging.error("Jolt failed to start: %s", ex)
-            sys.exit(0)
-            return
+
+            dlg = wx.MessageDialog(
+                None,
+                "Connection to Jolt failed. Make sure the hardware is connected and turned on and restart the application",
+                'Info', wx.OK | wx.ICON_INFORMATION
+            )
+
+            if dlg.ShowModal() == wx.ID_OK:
+                dlg.Destroy()
+                self.dialog.Close()
+                # The compiled Windows app has troubles nicely shutting down, therefore explicetely force it to stop.
+                sys.exit(0)
+                return
         except Exception as ex:
             logging.error("Jolt failed to start: %s", ex)
             sys.exit(0)
@@ -168,14 +183,90 @@ class JoltApp(wx.App):
             logging.debug("Changing front-end offset from %s to %s", old_fe_offset, fe_offset)
             self.dev.set_frontend_offset(fe_offset)
 
+        # Override XRC default values, since they are static and do not work for different JOLT versions
+        self.spinctrl_voltage.SetMin(0)  # For now, now differentiation for the lower bound
+        self.spinctrl_voltage.SetMax(self.dev.voltage_range[1])
+        self.voltage_gui = min(self.voltage, self.dev.voltage_range[1])
+        self.spinctrl_voltage.SetValue(self.voltage_gui)
+
         # Start the thread for polling
         self.polling_thread = threading.Thread(target=self.do_poll)
         self.polling_thread.start()
 
+        # Initialize calibration thread
+        self.calibration_thread = threading.Thread(target=self.calibrate)
+
+        # Calibration is only available for JOLT V2
+        if self.dev.version == 2:
+            self.load_calibration_file()  # Populates self.valid_calibration and self.calibration_table
+            if not self.valid_calibration:
+                no_calibration_dialog_text = "No (valid) calibration file available. The data will be unreliable, contact Delmic support (support@delmic.com) to obtain the calibration file. Use the JOLT anyway?"
+                dlg = wx.MessageDialog(None, no_calibration_dialog_text, 'Warning', wx.OK | wx.CANCEL | wx.ICON_WARNING)
+                dlg.SetOKCancelLabels("Continue", "Quit")
+                result = dlg.ShowModal()
+                if result == wx.ID_CANCEL:
+                    self.dialog.Close()
+            else:
+                logging.info(f"Matching calibration file found: {self.calibration_file}")
+
         # Don't write voltage to device yet, but show value in the gui
-        self.spinctrl_voltage.SetValue(self.voltage_gui)
         self.spinctrl_voltage.SetForegroundColour((211, 211, 211))
+        # Set fe offset controls to visible first and then immediately toggle off,
+        # so it calculates the sizes correctly.
+        self.fe_offset_visible = True
+        self.on_fe_offset_toggle(None)
         self.refresh()
+
+    def load_calibration_file(self):
+        """
+        Attempts to load calibration file. If successful, the file is loaded and stored as a table.
+        If file is not present or incomplete, it is not a valid calibration.
+
+        :sideeffect self.calibration_table: List[dict] or None, rows of the calibration table containing a dict with
+            structure <measurement>: <value>. For example: [{"temperature_target": "20", ...}, ...].
+        :sideeffect self.valid_calibration: Bool, whether the calibration is successfully loaded and whether it is
+            complete and compatible with the current settings.
+        """
+        # If no manually selected calibration was found, pick the latest one available on the system
+        if (self.calibration_file and not Path(self.calibration_file).exists()):
+            logging.error(f"Provided calibration file: {self.calibration_file}, but it does not exist")
+        else:
+            calibration_files = sorted(Path(self.dirs.user_data_dir).glob(
+                f"jolt-calibration-{self.dev.get_fe_sn()}*feo.tsv"))
+            if len(calibration_files):
+                self.calibration_file = calibration_files[-1]
+
+        self.calibration_table = None
+        self.valid_calibration = False
+        if self.calibration_file:
+            try:
+                dtype_lookup = {
+                    "temperature_target": float,
+                    "temperature": float,
+                    "voltage_target": float,
+                    "voltage": float,
+                    "fe_offset": int,
+                    "channel": lambda c: driver.Channel[c]
+                }
+                with open(self.calibration_file, "r") as file:
+                    reader = csv.DictReader(file, delimiter="\t")
+                    # In csv everything is a string, so convert to the appropriate dtypes.
+                    self.calibration_table = [{k: dtype_lookup[k](v) for k, v in row.items()} for row in reader]
+                    # Furthermore, go over the list one more time to filter for mppc temperature
+                    self.calibration_table = list(filter(
+                        lambda x : x["temperature_target"] == self.target_mppc_temp,
+                        self.calibration_table
+                    ))
+
+            except Exception as ex:
+                logging.error(f"Loading {self.calibration_file} failed: {ex}")
+        if self.calibration_table:
+            expected_channel_count = 4 if self.rgb_filter else 1
+            channels_in_calibration_file = set([r["channel"] for r in self.calibration_table])
+            self.valid_calibration = len(channels_in_calibration_file) == expected_channel_count
+
+            if not self.valid_calibration:
+                logging.error(f"Calibration file found: {self.calibration_file}, but does not contain data for all the channels")
 
     def load_config(self, section):
         """
@@ -191,6 +282,8 @@ class JoltApp(wx.App):
             (tuple, tuple, tuple, tuple): mppc_temp_rel, heatsink_temp, mppc_current, vacuum_pressure
         if section is 'SIGNAL':
            (bool, bool): differential, rgb_filter
+        if section is 'CALIBRATION':
+           (str, tuple, tuple): calibration_file, calibration_temps, calibration_voltage_range
         """
         if self.config is None:
             self.config = configparser.ConfigParser(converters={'tuple': self.get_tuple})
@@ -237,7 +330,7 @@ class JoltApp(wx.App):
                 mppc_current = driver.SAFERANGE_MPCC_CURRENT
                 vacuum_pressure = driver.SAFERANGE_VACUUM_PRESSURE
             return mppc_temp_rel, heatsink_temp, mppc_current, vacuum_pressure
-        if section == 'SIGNAL':
+        elif section == 'SIGNAL':
             try:
                 differential = self.config.getboolean('SIGNAL', 'differential', fallback=False)
                 rgb_filter = self.config.getboolean('SIGNAL', 'rgb_filter', fallback=True)
@@ -246,6 +339,29 @@ class JoltApp(wx.App):
                 differential = False
                 rgb_filter = True
             return differential, rgb_filter
+        elif section == 'CALIBRATION':
+            try:
+                calibration_file = self.config.get('CALIBRATION', 'calibration_file', fallback=None)
+                calibration_temps = self.config.gettuple('CALIBRATION', 'calibration_temps', fallback=None)
+                calibration_voltage_range = self.config.gettuple('CALIBRATION', 'calibration_voltage_range', fallback=None)
+
+                mppc_temp = self.config.getint('TARGET', 'mppc_temp', fallback=MPPC_TEMP_POWER_ON)
+                calibration_temps_fallback = (mppc_temp, )
+                calibration_voltage_range_fallback = (30, 37, 1)  # min, max, step size
+                if calibration_temps is None:
+                    logging.warning("No calibration temperatures provided, will use 20 C now")
+                    calibration_temps = calibration_temps_fallback
+
+                if calibration_voltage_range is None:
+                    logging.warning("No calibration voltage range provided, will use the JOLT V2 range (30, 37, 1)")
+                    calibration_voltage_range = calibration_voltage_range_fallback
+            except Exception as ex:
+                logging.error("Invalid CALIBRATION value, falling back to default values, ex: %s", ex)
+                calibration_file = None
+                calibration_temps = calibration_temps_fallback
+                calibration_voltage_range = calibration_voltage_range_fallback
+
+            return calibration_file, calibration_temps, calibration_voltage_range
         else:
             raise ValueError("No available section with name %s in the config file", section)
 
@@ -321,20 +437,29 @@ class JoltApp(wx.App):
 
         # voltage
         self.spinctrl_voltage = xrc.XRCCTRL(self.dialog, 'spn_voltage')
+
+        self.text_voltage = xrc.XRCCTRL(self.dialog, 'text_voltage')
         self.dialog.Bind(wx.EVT_SPINCTRLDOUBLE, self.on_voltage_value, id=xrc.XRCID('spn_voltage'))
         self.dialog.Bind(wx.EVT_TEXT_ENTER, self.on_voltage_value, id=xrc.XRCID('spn_voltage'))
 
-        # gain and offset
+        # gain and offsets
+        self.text_fe_offset = xrc.XRCCTRL(self.dialog, 'text_fe_offset')
+        self.unit_fe_offset = xrc.XRCCTRL(self.dialog, 'unit_fe_offset')
         self.slider_gain = xrc.XRCCTRL(self.dialog, 'slider_gain')
         self.slider_offset = xrc.XRCCTRL(self.dialog, 'slider_offset')
+        self.slider_fe_offset = xrc.XRCCTRL(self.dialog, 'slider_fe_offset')
         self.spinctrl_gain = xrc.XRCCTRL(self.dialog, 'spin_gain')
         self.spinctrl_offset = xrc.XRCCTRL(self.dialog, 'spin_offset')
+        self.spinctrl_fe_offset = xrc.XRCCTRL(self.dialog, 'spin_fe_offset')
         self.dialog.Bind(wx.EVT_SCROLL, self.on_gain_slider, id=xrc.XRCID('slider_gain'))
         self.dialog.Bind(wx.EVT_SCROLL, self.on_offset_slider, id=xrc.XRCID('slider_offset'))
+        self.dialog.Bind(wx.EVT_SCROLL, self.on_fe_offset_slider, id=xrc.XRCID('slider_fe_offset'))
         self.dialog.Bind(wx.EVT_SPINCTRLDOUBLE, self.on_gain_spin, id=xrc.XRCID('spin_gain'))
         self.dialog.Bind(wx.EVT_SPINCTRLDOUBLE, self.on_offset_spin, id=xrc.XRCID('spin_offset'))
+        self.dialog.Bind(wx.EVT_SPINCTRLDOUBLE, self.on_fe_offset_spin, id=xrc.XRCID('spin_fe_offset'))
         self.dialog.Bind(wx.EVT_TEXT_ENTER, self.on_gain_spin, id=xrc.XRCID('spin_gain'))
         self.dialog.Bind(wx.EVT_TEXT_ENTER, self.on_offset_spin, id=xrc.XRCID('spin_offset'))
+        self.dialog.Bind(wx.EVT_TEXT_ENTER, self.on_fe_offset_spin, id=xrc.XRCID('spin_fe_offset'))
 
         # channel selection
         self.channel_ctrl = xrc.XRCCTRL(self.dialog, 'radio_channel')
@@ -352,6 +477,9 @@ class JoltApp(wx.App):
         self.txtbox_MPPCTemp = xrc.XRCCTRL(self.dialog, 'txtbox_MPPCTemp')
         self.txtbox_sinkTemp = xrc.XRCCTRL(self.dialog, 'txtbox_sinkTemp')
         self.txtbox_vacuumPressure = xrc.XRCCTRL(self.dialog, 'txtbox_vacuumPressure')
+        self.text_fe_output = xrc.XRCCTRL(self.dialog, 'text_fe_output')
+        self.txtbox_fe_output = xrc.XRCCTRL(self.dialog, 'txtbox_fe_output')
+        self.unit_fe_output = xrc.XRCCTRL(self.dialog, 'unit_fe_output')
 
         # log display
         # FIXME: at init, the CollapsiblePane is collapsed but still takes space
@@ -360,15 +488,21 @@ class JoltApp(wx.App):
 
         # catch the closing event
         self.dialog.Bind(wx.EVT_CLOSE, self.on_close)
-        
+
         # Debug mode: allow F5 + "delmic" password to enable all controls
         # Inspection window: Ctrl+I (in debug mode) to show GUI controls
         f5_id = 1
         inspect_id = 2
+        calibration_id = 3
+        fe_offset_toggle_id = 4
         self.dialog.Bind(wx.EVT_MENU, self.on_f5, id=f5_id)
         self.dialog.Bind(wx.EVT_MENU, self.on_inspect, id=inspect_id)
+        self.dialog.Bind(wx.EVT_MENU, self.on_calibration, id=calibration_id)
+        self.dialog.Bind(wx.EVT_MENU, self.on_fe_offset_toggle, id=fe_offset_toggle_id)
         accel_tbl = wx.AcceleratorTable([(wx.ACCEL_NORMAL, wx.WXK_F5, f5_id),
-                                         (wx.ACCEL_CTRL, ord('I'), inspect_id)])
+                                         (wx.ACCEL_CTRL, ord('I'), inspect_id),
+                                         (wx.ACCEL_CTRL, ord('K'), calibration_id),
+                                         (wx.ACCEL_CTRL, ord('O'), fe_offset_toggle_id),])
         self.dialog.SetAcceleratorTable(accel_tbl)
         self.power_label = xrc.XRCCTRL(self.dialog, 'm_staticText16')  # will be updated in debug mode
         self.txtbox_output.SetFocus()  # if focus is None, the f5 event is not captured, so set focus to a textbox
@@ -406,9 +540,9 @@ class JoltApp(wx.App):
 
         # Change maximum voltage in debug mode (too high voltage can hurt the system if it's not covered)
         if self.debug_mode:
-            self.spinctrl_voltage.SetMax(52)  # just enough to get signal
+            self.spinctrl_voltage.SetMax(self.dev.voltage_range[0])  # just enough to get signal
         else:
-            self.spinctrl_voltage.SetMax(70)  # as usual
+            self.spinctrl_voltage.SetMax(self.dev.voltage_range[1])  # as usual
 
     def check_saferange(self, textctrl, val, srange, name, t=None):
         """
@@ -464,12 +598,19 @@ class JoltApp(wx.App):
                 del self.attrs_to_watch[name]
 
     def on_close(self, event):
+        if self.calibrating:
+            dlg = wx.MessageDialog(None, "Calibration still in progress. Closing aborts the running calibration. Go ahead?", 'Warning', wx.OK | wx.CANCEL | wx.ICON_WARNING)
+            dlg.SetOKCancelLabels("Close app", "Continue calibration")
+            result = dlg.ShowModal()
+            if result == wx.ID_CANCEL:
+                return
+
         # If device is powered on, ask use to power it off first
         if self.power:
             dlg = wx.MessageDialog(None, "Power down the Jolt hardware before closing the application?", 'Notice', wx.OK | wx.CANCEL | wx.ICON_WARNING)
             dlg.SetOKCancelLabels("Power down", "Cancel closing")
             result = dlg.ShowModal()
- 
+
             if result == wx.ID_OK:
                 logging.info("Powering down Jolt...")
                 try:
@@ -482,7 +623,12 @@ class JoltApp(wx.App):
             else:
                 return  # Cancel closing
 
-        self.should_close.set()  # Stop the polling thread
+        self.should_stop_polling.set()  # Stop the polling thread
+        self.should_stop_calibration.set()  # Stop the polling thread
+        if self.polling_thread and self.polling_thread.is_alive():
+            self.polling_thread.join()
+        if self.calibration_thread and self.calibration_thread.is_alive():
+            self.calibration_thread.join()
         self.save_config()  # Save config to INI
         self.dialog.Destroy()
         event.Skip()
@@ -497,6 +643,97 @@ class JoltApp(wx.App):
         if self.debug_mode:
             from wx.lib.inspection import InspectionTool
             InspectionTool().Show()
+
+    def calibrate(self):
+        logging.info("Calibration started.")
+        self.calibrating = True
+        feo_calib.run(
+            self.dev,
+            temperatures=self.calibration_temps,
+            voltage_range=self.calibration_voltage_range,
+            stop_event=self.should_stop_calibration,
+            channels = feo_calib.CHANNELS if self.rgb_filter else [driver.Channel.PANCHROMATIC],
+        )
+        self.calibrating = False
+        logging.info("Calibration ended.")
+
+    @call_in_wx_main
+    def on_fe_offset_toggle(self, event):
+        elements = [
+            # Offset
+            self.text_fe_offset,
+            self.slider_fe_offset,
+            self.spinctrl_fe_offset,
+            self.unit_fe_offset,
+            # Output
+            self.text_fe_output,
+            self.txtbox_fe_output,
+            self.unit_fe_output,
+        ]
+
+        self.fe_offset_visible = not self.fe_offset_visible
+        for element in elements:
+            element.Show(self.fe_offset_visible)
+        self.dialog.Layout()
+        self.dialog.Fit()
+
+    def open_log(self):
+        if hasattr(self.btn_viewLog, "Collapse"):
+            self.btn_viewLog.Collapse(False)
+        # On Windows, this element is a button that sadly does not have the Collapse() method.
+        # We can still toggle it by simulating a click on the button element in the control element.
+        # We only click it when it is not yet open. We use a height heuristic for this.
+        elif self.btn_viewLog.GetSize()[1] < 100:
+            ui_sim = wx.UIActionSimulator()
+            original_pos = wx.GetMousePosition()
+            # This is the top left coordinate. The button happens to be right there. The element
+            # itself is the entire log, so obtaining the size is not the size of the button, but the log element.
+            log_pos = self.btn_viewLog.ScreenPosition
+            # Offset the top left coordinate so we end up in the area of the button.
+            log_pos = (log_pos[0] + 5, log_pos[1] + 5)
+            ui_sim.MouseMove(*log_pos)
+            ui_sim.MouseClick()
+            # Move back to original position, so we don't really notice this hack during use
+            ui_sim.MouseMove(*original_pos)
+
+    @call_in_wx_main
+    def on_calibration(self, event):
+        if self.debug_mode:
+            if not self.calibration_thread.is_alive():
+                dlg = wx.MessageDialog(
+                    None,
+                    "Do you want to calibrate the front-end offset?",
+                    'Calibration',
+                    wx.YES_NO | wx.ICON_QUESTION
+                )
+                result = dlg.ShowModal()
+                dlg.Destroy()
+                if result == wx.ID_YES:
+                    self.should_stop_polling.set()
+                    self.should_stop_calibration.clear()
+                    self.calibration_thread = threading.Thread(target=self.calibrate)
+                    self.calibration_thread.start()
+                    self.open_log()
+                else:
+                    logging.info("Calibration canceled.")
+            else:
+                dlg = wx.MessageDialog(
+                    None,
+                    "Calibration in progress. Abort?",
+                    "Cancel calibration",
+                    wx.YES_NO | wx.ICON_QUESTION
+                )
+                result = dlg.ShowModal()
+                dlg.Destroy()
+                if result == wx.ID_YES:
+                    self.should_stop_calibration.set()
+                    self.calibration_thread.join()
+                    self.should_stop_polling.clear()
+                    self.polling_thread = threading.Thread(target=self.do_poll)
+                    self.polling_thread.start()
+                    logging.info("Calibration canceled.")
+                else:
+                    logging.info("Calibration continuing.")
 
     def toggle_power(self):
         if self.ctl_power.IsEnabled():
@@ -523,7 +760,7 @@ class JoltApp(wx.App):
 
     def on_voltage_button(self, event):
         """
-        Enable/disable voltage changes. If disabled, set voltage to 0. 
+        Enable/disable voltage changes. If disabled, set voltage to 0.
         """
         # Toggle the HV value
         if self.ctl_hv.IsEnabled():
@@ -532,34 +769,76 @@ class JoltApp(wx.App):
 
             if self.hv:
                 # write parameters to device
-                self.dev.set_voltage(self.voltage_gui)
+                self.dev.adjust_voltage(self.voltage_gui)
+                if self.valid_calibration:
+                    self.set_matching_calibrated_offset()
                 self.spinctrl_voltage.SetForegroundColour(wx.Colour(wx.BLACK))
             else:
                 self.dev.set_voltage(0)
                 # light grey to show it's not actually set
                 self.spinctrl_voltage.SetForegroundColour((211, 211, 211))
-                self.spinctrl_voltage.SetValue(self.voltage_gui)
         self.refresh()
 
     def on_auto_bc(self, event):
         raise NotImplementedError()
         # disable gain/offset controls
 
+    def set_matching_calibrated_offset(self):
+        # Ignore temperature inaccuracies for now and just use the target to simplify things.
+        voltage_dists = {i: abs(r["voltage"] - self.voltage_gui) for i, r in enumerate(self.calibration_table)
+            if r["channel"] == STR2CHANNEL[self.channel]}
+
+        # Obtain the two closest calibration points for interpolation
+        idx_within_channel_low = argmin(voltage_dists.values())[0]
+        idx_within_channel_high = argmin(voltage_dists.values())[1]
+
+        match_idx_low = list(voltage_dists.keys())[idx_within_channel_low]
+        match_idx_high = list(voltage_dists.keys())[idx_within_channel_high]
+
+        matching_voltage_low = self.calibration_table[match_idx_low]["voltage_target"]
+        matching_voltage_high = self.calibration_table[match_idx_high]["voltage_target"]
+
+        matching_offset_low = self.calibration_table[match_idx_low]["fe_offset"]
+        matching_offset_high = self.calibration_table[match_idx_high]["fe_offset"]
+
+        # Interpolate to obtain the matching offset
+        slope, intercept = linear_regression([
+            (matching_voltage_low, matching_offset_low),
+            (matching_voltage_high, matching_offset_high),
+        ])
+
+        matching_offset = int(slope * self.voltage_gui + intercept)
+
+        # Clip
+        matching_offset = max(0, min(matching_offset, 1023))
+
+        self.dev.set_frontend_offset(matching_offset)
+        logging.info(f"Front-end offset is set to {matching_offset} at {self.voltage_gui} V, based on calibration data")
+        self.slider_fe_offset.SetValue(matching_offset)
+        self.spinctrl_fe_offset.SetValue(matching_offset)
+
     def on_voltage_value(self, event):
         """
         Set voltage if voltage change enabled, otherwise ignore.
         """
-        self.voltage_gui = self.spinctrl_voltage.GetValue()
+        voltage = float(event.GetString())
+        self.voltage_gui = voltage
+        # This makes sure that formatting rules apply and focus is regained.
+        # For example: 20 becomes 20.00 if precision is 2 for instance.
+        self.spinctrl_voltage.SetValue(voltage)
         if self.hv:
             logging.debug("Changed voltage to %s", self.voltage_gui)
-            self.dev.set_voltage(self.voltage_gui)
-        # Set focus to dialog when we're done, so the ctrl will update with values from the hw
-        self.txtbox_output.SetFocus()
+            self.dev.adjust_voltage(self.voltage_gui)
+            if self.valid_calibration:
+                self.set_matching_calibrated_offset()
         event.Skip()
 
     def on_radiobox(self, event):
+        self.channel = event.GetEventObject().GetStringSelection()
         self.dev.set_channel(STR2CHANNEL[event.GetEventObject().GetStringSelection()])
         logging.debug("Changed channel to %s", event.GetEventObject().GetStringSelection())
+        if self.valid_calibration:
+            self.set_matching_calibrated_offset()
 
     def on_gain_slider(self, event):
         gain = event.GetPosition()
@@ -573,19 +852,35 @@ class JoltApp(wx.App):
         self.dev.set_offset(offset)
         logging.debug("Changed offset to %s", offset)
 
+    def on_fe_offset_slider(self, event):
+        offset = event.GetPosition()
+        self.spinctrl_fe_offset.SetValue(offset)
+        self.dev.set_frontend_offset(offset)
+        logging.debug("Changed front-end offset to %s", offset)
+
     def on_gain_spin(self, event):
-        gain = self.spinctrl_gain.GetValue()
-        self.slider_gain.SetValue(int(gain))
+        gain = int(float(event.GetString()))
+        self.slider_gain.SetValue(gain)
+        self.spinctrl_gain.SetValue(gain)
         self.dev.set_gain(gain)
         logging.debug("Changed gain to %s", gain)
-        self.txtbox_output.SetFocus()
+        event.Skip()
 
     def on_offset_spin(self, event):
-        offset = self.spinctrl_offset.GetValue()
-        self.slider_offset.SetValue(int(round(offset)))
+        offset = round(int(float(event.GetString())))
+        self.slider_offset.SetValue(offset)
+        self.spinctrl_offset.SetValue(offset)
         self.dev.set_offset(offset)
         logging.debug("Changed offset to %s", offset)
-        self.txtbox_output.SetFocus()
+        event.Skip()
+
+    def on_fe_offset_spin(self, event):
+        offset = int(float(event.GetString()))
+        self.slider_fe_offset.SetValue(offset)
+        self.spinctrl_fe_offset.SetValue(offset)
+        self.dev.set_frontend_offset(offset)
+        logging.debug("Changed front-end offset to %s", offset)
+        event.Skip()
 
     @call_in_wx_main
     def update_controls(self):
@@ -612,8 +907,10 @@ class JoltApp(wx.App):
             self.spinctrl_voltage.Enable(True)
             self.slider_gain.Enable(True)
             self.slider_offset.Enable(True)
+            self.slider_fe_offset.Enable(True)
             self.spinctrl_gain.Enable(True)
             self.spinctrl_offset.Enable(True)
+            self.spinctrl_fe_offset.Enable(True)
         elif (pressure_ok or self.ambient) and heatsink_ok and not self.error_codes:
             # enable power, disable rest
             # don't care about pressure in ambient mode
@@ -623,10 +920,12 @@ class JoltApp(wx.App):
             self.ctl_hv.SetBitmap(disable_bmp(self.bmp_on) if self.hv else disable_bmp(self.bmp_off))
             self.channel_ctrl.Enable(False)
             self.spinctrl_voltage.Enable(False)
+            self.slider_fe_offset.Enable(False)
             self.slider_gain.Enable(False)
             self.slider_offset.Enable(False)
             self.spinctrl_gain.Enable(False)
             self.spinctrl_offset.Enable(False)
+            self.spinctrl_fe_offset.Enable(False)
         else:
             # disable all
             self.ctl_power.Enable(False)
@@ -654,7 +953,7 @@ class JoltApp(wx.App):
         Refreshes the GUI display values
         """
         # Check the error status
-        if self.error != 8:
+        if self.error != driver.FrontEndErrorCodes.NoFault.value:
             if not self.error in self.error_codes:
                 msg = wx.adv.NotificationMessage("DELMIC JOLT", message="Jolt reports error code %d." % (self.error,) +
                                                  " Verify that the control box is connected " +
@@ -673,6 +972,7 @@ class JoltApp(wx.App):
         self.txtbox_output.SetValue("%.2f" % self.output)
         self.txtbox_MPPCTemp.SetValue("%.1f" % self.mppc_temp)
         self.txtbox_sinkTemp.SetValue("%.1f" % self.heat_sink_temp)
+        self.txtbox_fe_output.SetValue("%.3f" % self.fe_output)
         pressure_ok = self.saferange_vacuum_pressure[0] <= self.vacuum_pressure <= self.saferange_vacuum_pressure[1]
         if pressure_ok:
             self.txtbox_vacuumPressure.SetValue("vacuum")
@@ -714,8 +1014,10 @@ class JoltApp(wx.App):
         for ctrl, val in [(self.spinctrl_gain, self.gain), (self.spinctrl_offset, self.offset)]:
             if focus != ctrl and focus_name != 'text':
                 ctrl.SetValue(round(float(val), 1))
-        if self.hv and focus != self.spinctrl_voltage and focus_name != 'text':
-            self.spinctrl_voltage.SetValue(round(float(self.voltage), 2))
+        voltage_numeric = round(float(self.voltage), 2)
+        voltage_string = f"({voltage_numeric} V)"
+        self.text_voltage.SetLabel(voltage_string)
+        self.text_voltage.SetToolTip("Measured voltage")
 
         # Grey out value in voltage control if voltage button is off.
         # In this case, the actual voltage will be 0, but we still want the previous
@@ -724,11 +1026,6 @@ class JoltApp(wx.App):
             self.spinctrl_voltage.SetForegroundColour(wx.BLACK)
         elif not self.hv and focus != self.spinctrl_voltage and focus_name != 'text':
             self.spinctrl_voltage.SetForegroundColour((211, 211, 211))  # light grey
-            # Colour is only updated if text is changed, so quickly change to value
-            # that is never reached (only in the gui of course) and back, so it's never
-            # noticed.
-            self.spinctrl_voltage.SetValue(100)
-            self.spinctrl_voltage.SetValue(self.voltage_gui)
 
         # Update controls
         self.update_controls()
@@ -738,12 +1035,12 @@ class JoltApp(wx.App):
         This function is run in a thread and handles the polling of the device on a time interval
         """
         try:
-            while not self.should_close.is_set():
+            while not self.should_stop_polling.is_set():
                 # Get new values from the device
                 if not self.differential:
                     self.output = self.dev.get_output_single_ended()
                 else:
-                    self.output = self.dev.get_plus_reading_differential()
+                    self.output = self.dev.get_output_differential()
                 self.gain = self.dev.get_gain()
                 self.offset = self.dev.get_offset()
                 self.voltage = self.dev.get_voltage()
@@ -753,11 +1050,17 @@ class JoltApp(wx.App):
                 self.vacuum_pressure = self.dev.get_vacuum_pressure()
                 self.error = self.dev.get_error_status()
                 self.itec = self.dev.get_itec()
+                # Properties purely for logging
+                target_temp = self.dev.get_mppc_temp()
+                fe_offset = self.dev.get_frontend_offset()
+                self.fe_output = self.dev.get_frontend_output_voltage()
+                # Convert error code 8 (no error) to more user friendly string
+                error_log = self.error if self.error != driver.FrontEndErrorCodes.NoFault.value else "no errors"
 
-                logging.info("Gain: %.2f, offset: %.2f, channel: %s, temperature: %.2f, sink temperature: %.2f, " +
-                             "pressure: %.2f, voltage: %.2f, output: %.2f, error state: %d, Tec current: %s", self.gain, self.offset,
-                             self.channel, self.mppc_temp, self.heat_sink_temp, self.vacuum_pressure, self.voltage, self.output,
-                             self.error, self.itec)
+                logging.info("Gain: %.2f, offset: %.2f, channel: %s, target temperature: %.2f, temperature: %.2f, sink temperature: %.2f, " +
+                             "pressure: %.2f, voltage: %.2f, output: %.2f, fe offset: %d, fe output: %.3e, error state: %s, Tec current: %s", self.gain, self.offset,
+                             self.channel, target_temp, self.mppc_temp, self.heat_sink_temp, self.vacuum_pressure, self.voltage, self.output, fe_offset, self.fe_output,
+                             error_log, self.itec)
 
                 # Refresh gui with these values
                 self.refresh()

--- a/src/jolt/gui/jolt_app.xrc
+++ b/src/jolt/gui/jolt_app.xrc
@@ -52,7 +52,6 @@
 						<flag>wxBOTTOM</flag>
 						<border>5</border>
 						<object class="wxStaticBitmap" name="m_bitmap11">
-							<bg>#f0f0f0</bg>
 							<fg>#ababab</fg>
 							<bitmap>img/delmic_logo.png</bitmap>
 						</object>
@@ -73,7 +72,7 @@
 				<border>5</border>
 				<object class="wxFlexGridSizer">
 					<rows>1</rows>
-					<cols>4</cols>
+					<cols>5</cols>
 					<vgap>0</vgap>
 					<hgap>0</hgap>
 					<growablecols></growablecols>
@@ -103,10 +102,11 @@
 						<object class="wxSpinCtrlDouble" name="spn_voltage">
 							<style>wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</style>
 							<size>85,-1</size>
+							<tooltip>Target voltage</tooltip>
 							<value>3.600000</value>
 							<min>0</min>
 							<max>70</max>
-							<inc>0.05</inc>
+							<inc>0.1</inc>
 							<digits>2</digits>
 						</object>
 					</object>
@@ -116,6 +116,16 @@
 						<border>5</border>
 						<object class="wxStaticText" name="m_staticText2">
 							<label>V</label>
+							<wrap>-1</wrap>
+						</object>
+					</object>
+					<object class="sizeritem">
+						<option>0</option>
+						<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+						<border>5</border>
+						<object class="wxStaticText" name="text_voltage">
+							<label></label>
+							<hover></hover>
 							<wrap>-1</wrap>
 						</object>
 					</object>
@@ -133,7 +143,7 @@
 						<flag>wxEXPAND</flag>
 						<border>5</border>
 						<object class="wxFlexGridSizer">
-							<rows>3</rows>
+							<rows>4</rows>
 							<cols>4</cols>
 							<vgap>0</vgap>
 							<hgap>0</hgap>
@@ -188,7 +198,7 @@
 							</object>
 							<object class="sizeritem">
 								<option>2</option>
-								<flag>wxALL|wxEXPAND</flag>
+								<flag>wxALL|wxEXPAND|wxALIGN_CENTER_VERTICAL</flag>
 								<border>5</border>
 								<object class="wxSlider" name="slider_gain">
 									<style>wxSL_BOTTOM|wxSL_HORIZONTAL</style>
@@ -200,7 +210,7 @@
 							</object>
 							<object class="sizeritem">
 								<option>1</option>
-								<flag>wxALL|wxALIGN_RIGHT</flag>
+								<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
 								<border>5</border>
 								<object class="wxSpinCtrlDouble" name="spin_gain">
 									<style>wxALIGN_LEFT|wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</style>
@@ -215,7 +225,7 @@
 							<object class="sizeritem">
 								<option>1</option>
 								<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
-								<border>5</border>
+								<border>10</border>
 								<object class="wxStaticText" name="m_staticText19">
 									<label>%</label>
 									<wrap>-1</wrap>
@@ -232,7 +242,7 @@
 							</object>
 							<object class="sizeritem">
 								<option>0</option>
-								<flag>wxALL|wxEXPAND</flag>
+								<flag>wxALL|wxEXPAND|wxALIGN_CENTER_VERTICAL</flag>
 								<border>5</border>
 								<object class="wxSlider" name="slider_offset">
 									<style>wxSL_BOTTOM|wxSL_HORIZONTAL</style>
@@ -244,7 +254,7 @@
 							</object>
 							<object class="sizeritem">
 								<option>1</option>
-								<flag>wxALL|wxALIGN_BOTTOM</flag>
+								<flag>wxALL|wxALIGN_BOTTOM|wxALIGN_CENTER_VERTICAL</flag>
 								<border>5</border>
 								<object class="wxSpinCtrlDouble" name="spin_offset">
 									<style>wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</style>
@@ -259,9 +269,53 @@
 							<object class="sizeritem">
 								<option>1</option>
 								<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
-								<border>5</border>
+								<border>10</border>
 								<object class="wxStaticText" name="m_staticText20">
 									<label>%</label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="text_fe_offset">
+									<label>Offset (FE)</label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxALL|wxEXPAND|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<object class="wxSlider" name="slider_fe_offset">
+									<style>wxSL_BOTTOM|wxSL_HORIZONTAL</style>
+									<size>180,-1</size>
+									<value>512</value>
+									<min>0</min>
+									<max>1023</max>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxALIGN_BOTTOM|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<object class="wxSpinCtrlDouble" name="spin_fe_offset">
+									<style>wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</style>
+									<size>75,-1</size>
+									<value>512</value>
+									<min>0</min>
+									<max>1023</max>
+									<inc>1</inc>
+									<digits>0</digits>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>1</option>
+								<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>10</border>
+								<object class="wxStaticText" name="unit_fe_offset">
+									<label></label>
 									<wrap>-1</wrap>
 								</object>
 							</object>
@@ -293,7 +347,7 @@
 						<flag>wxEXPAND</flag>
 						<border>5</border>
 						<object class="wxFlexGridSizer">
-							<rows>4</rows>
+							<rows>6</rows>
 							<cols>3</cols>
 							<vgap>5</vgap>
 							<hgap>5</hgap>
@@ -404,6 +458,33 @@
 								<border>5</border>
 								<object class="wxStaticText" name="m_staticText141">
 									<label></label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+														<object class="sizeritem">
+								<option>0</option>
+								<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="text_fe_output">
+									<label>Output (FE)</label>
+									<wrap>-1</wrap>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxALL</flag>
+								<border>5</border>
+								<object class="wxTextCtrl" name="txtbox_fe_output">
+									<style>wxTE_READONLY|wxTE_RICH</style>
+									<value></value>
+								</object>
+							</object>
+							<object class="sizeritem">
+								<option>0</option>
+								<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
+								<border>5</border>
+								<object class="wxStaticText" name="unit_fe_output">
+									<label>V</label>
 									<wrap>-1</wrap>
 								</object>
 							</object>

--- a/src/jolt/util/array.py
+++ b/src/jolt/util/array.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+'''
+Module with array utilities.
+
+Created on 12 March 2025
+@author: Tim Moerkerken
+Copyright © 2025 Tim Moerkerken, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see http://www.gnu.org/licenses/.
+'''
+
+
+from typing import List
+
+
+def arange(vmin: float, vmax: float, step: float) -> List[float]:
+    """
+    Generates a list of values starting from vmin and adding steps while staying below vmax.
+
+    :param vmin: The minimum value (inclusive).
+    :param vmax: The maximum value (exclusive).
+    :param step: The step size between consecutive values.
+    :return: A list of values from vmin to just below vmax with the specified step.
+    """
+    values = []
+    current = vmin
+    while current < vmax:
+        values.append(current)
+        current += step
+    return values

--- a/src/jolt/util/feo_calib.py
+++ b/src/jolt/util/feo_calib.py
@@ -1,0 +1,378 @@
+# -*- coding: utf-8 -*-
+'''
+Module to calibrate the offset of the Jolt front-end board.
+
+Created on 12 March 2025
+@author: Tim Moerkerken
+Copyright © 2025 Tim Moerkerken, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see http://www.gnu.org/licenses/.
+'''
+
+from jolt.util.measurement import (
+                                    repeated_get,
+                                    await_set,
+                                    await_set_stabilized,
+                                  )
+
+from jolt.driver.joltcb import Channel, JOLTComputerBoard
+from jolt.util.array import arange
+from typing import List, Tuple, Optional
+import logging
+import statistics
+from datetime import datetime, timedelta
+import csv
+import time
+from appdirs import AppDirs
+from pathlib import Path
+from threading import Event
+from typing import Union
+
+logging.basicConfig()
+logger = logging.getLogger()
+
+CHANNELS = [Channel.RED, Channel.BLUE, Channel.GREEN, Channel.PANCHROMATIC]
+TARGET_OP_TEMPS = [25]
+OP_VOLTAGE_RANGE = (30, 37, 1)
+FE_OFFSET_RANGE = (0, 1023)
+
+OFFSET_LOOKBACK_VALUE = 3
+STOP_EVENT_STRING = "ABORT"
+
+
+def find_zero_offset_binary(dev, input_range: Tuple, stop_event: Event = None) -> Union[int, str]:
+    """
+    Optimization function to find the minimum offset that results in a 0 V output voltage.
+
+    :param dev: the computer board driver class.
+    :param input_range: the offset search space, (min, max), unitless.
+    :param stop_event: a handle to stop the calibration process during a run.
+    :return: the optimal offset within provided input range. Returns the string 'aborted' when cancelled during run.
+    """
+    min_offset = input_range[0]
+    max_offset = input_range[1]
+
+    while True:
+        if stop_event is not None and stop_event.is_set():
+            return STOP_EVENT_STRING
+
+        if min_offset == max_offset:
+            logger.warning("Was not able to normally converge within range")
+            return max_offset
+
+        input_offset_value = int(statistics.mean([min_offset, max_offset]))
+
+        # Since our method looks back to confirm the found offset is correct, we have to abort when the offset would
+        # become negative.
+        if input_offset_value <= OFFSET_LOOKBACK_VALUE:
+            return
+
+        await_set_stabilized(dev.set_frontend_offset, dev.get_frontend_offset, input_offset_value, tolerance=0.1)
+        # Wait a little, since the output voltage takes time to settle
+        time.sleep(0.2)
+        v_output_array = repeated_get(dev.get_frontend_output_voltage, repeats=5, interval=0.03)
+        v_output = statistics.median(v_output_array)
+        if v_output == 0:
+            # We measure no significant voltage, so we are somewhere higher than the optimal offset
+
+            # Output (V)
+            #    |
+            # Vm |
+            #    |
+            #    |⟍     →            ←
+            #    |  ⟍   →            ←
+            #    |    ⟍ →            ←
+            #    |_____ ⟍____________
+            #    0                  1023
+            #    Offset
+
+            # Check if we are close enough to the optimal value by looking back a little
+            # Not too little, for a bit of robustness against noise.
+            input_offset_value_convergence_check = input_offset_value - OFFSET_LOOKBACK_VALUE
+            await_set_stabilized(
+                dev.set_frontend_offset, dev.get_frontend_offset, input_offset_value_convergence_check, tolerance=0.1)
+            # Add some settle time
+            time.sleep(0.2)
+            v_convergence_array = repeated_get(dev.get_frontend_output_voltage, repeats=5, interval=0.03)
+            # Check if more significant signal than not is measured
+            if statistics.median(v_convergence_array) > 0:
+                # We are now here, which is where we can stop
+
+                # Output (V)
+                #    |
+                # Vm |
+                #    |
+                #    |⟍
+                #    |  ⟍    |
+                #    |    ⟍  |
+                #    |_____ ⟍↓__________
+                #    0                  1023
+                #    Offset
+                min_offset = input_offset_value  # For following operating voltages
+                return  input_offset_value
+            elif v_output < 0:
+                logger.error(f"Negative output voltage detected. \nPlease check the hardware for defects.")
+                raise ValueError(f"Negative output voltage detected ({v_output} V)")
+            else:
+                # Apparently we are still somewhere higher than the optimum
+
+                # Output (V)
+                #    |
+                # Vm |
+                #    |
+                #    |⟍
+                #    |  ⟍            |
+                #    |    ⟍          |
+                #    |_____ ⟍________↓___
+                #    0                  1023
+                #    Offset
+                # Set the max offset to the current value
+                max_offset = input_offset_value
+        elif v_output > 0:
+            # We are now somewhere here, so we need to go higher
+
+            # Output (V)
+            #    |
+            # Vm |
+            #    |
+            #    |⟍   |
+            #    |  ⟍ ↓
+            #    |    ⟍
+            #    |_____ ⟍__________
+            #    0                  1023
+            #    Offset
+            min_offset = input_offset_value
+        elif v_output < 0:
+            logger.error(f"Negative output voltage detected. \nPlease check the hardware for defects.")
+            raise ValueError(f"Negative output voltage detected ({v_output} V)")
+
+
+def find_initial_fe_offset(dev, stop_event: Event = None):
+    """
+    Optimization method to find the minimum offset that results in a 0 V output voltage.
+
+    :param dev: the computer board driver class.
+    :param stop_event: a handle to stop the calibration process during a run.
+    :return: the optimal initial offset. Returns the string 'aborted' when cancelled during run.
+    """
+    fe_offset = None
+    # Finding the initial point is critical, so keep attempting until found.
+    # The starting operating voltage is the least noisy, so ideally there is only
+    # one attempt needed.
+    attempts = 0
+    while not fe_offset:
+        if attempts >= 5:
+            logger.error("Was not able to find initial offset. "
+                        "Skipping entire channel. \n"
+                        "Please check the hardware for defects.")
+            break
+        logger.debug(f"Attempt {attempts + 1} to find initial offset")
+        attempts += 1
+        fe_offset = find_zero_offset_binary(dev, FE_OFFSET_RANGE, stop_event)
+        if fe_offset == STOP_EVENT_STRING:
+            return fe_offset
+
+    return fe_offset
+
+
+def find_subsequent_fe_offset(dev, fe_offset_initial, previous_op_voltage_offset_gap, stop_event: Event = None):
+    """
+    Method to find subsequent front-end offset that results in a 0 V output voltage in an optimized manner.
+    The optimizations use the following assumptions:
+    - The minimum offset that minimizes the output voltage always increases with increasing operating voltage.
+        As an example: if we find an offset of 500 for the first operating voltage, the next one should be 500 or more.
+    - The difference between offsets is increasing for increasing operating voltage
+        As an example: if an offset of 500 is found at 35 V, and an offset of 550 at 36 V, we expect an offset of at
+        least +50 at 37 V. This method will now use the previous offset plus a delta based on the previously measured
+        offset difference.
+
+    NOTE: The binary method can also work for these voltages, but it was found to be a bit more affected
+    by noise (sometimes not converging) and therefore slower.
+
+    :param dev: the computer board driver class.
+    :param fe_offset_initial: the initial front-end offset value to start the search with.
+    :param previous_op_voltage_offset_gap: the offset difference between found front-end offset values for
+        previously measured operating voltages.
+    :param stop_event: a handle to stop the calibration process during a run.
+    :return: the optimal initial offset. Returns the string 'aborted' when cancelled during run.
+    """
+    # When there is an offset difference known from the previous operating voltages, use it to start looking a bit
+    # further for the offset. When this difference is small, ignore it, since noise can dominate at this stage, and we
+    # might miss the optimal offset. We only go as far as 70% of the previous difference, again, to not overshoot due
+    # to earlier measured noise.
+    initial_shift = 0 if previous_op_voltage_offset_gap < 10 else int(previous_op_voltage_offset_gap * 0.7)
+    offset_candidate = fe_offset_initial + initial_shift
+    # From this initial candidate, the voltage will incrementally be increased until no significant voltage is found.
+    while True:
+        if stop_event is not None and stop_event.is_set():
+            return STOP_EVENT_STRING
+        if offset_candidate >= FE_OFFSET_RANGE[1]:
+            logger.warning(f"Was not able to converge within range")
+            return FE_OFFSET_RANGE[1]
+        await_set_stabilized(
+            dev.set_frontend_offset, dev.get_frontend_offset, offset_candidate, tolerance=0.1)
+        # Settle
+        time.sleep(0.2)
+        v_output_array = repeated_get(dev.get_frontend_output_voltage, repeats=5, interval=0.03)
+        # When no significant voltage is found, assume optimal offset is reached
+        v_output_median = statistics.median(v_output_array)
+        if v_output_median == 0:
+            return offset_candidate
+        elif v_output_median < 0:
+            logger.error(f"Negative output voltage detected. \nPlease check the hardware for defects.")
+            raise ValueError(f"Negative output voltage detected ({v_output_median} V)")
+
+        # The was no convergence yet, so keep going further
+
+        # Output (V)
+        #    |
+        # Vm |
+        #    |
+        #    |⟍   | →
+        #    |  ⟍ ↓ →
+        #    |    ⟍
+        #    |_____ ⟍__________
+        #    0                  1023
+        #    Offset
+
+        # Since the offset difference seems somewhat exponential, and since the signal becomes more
+        # noisy for larger operating voltages, keeping a small step size would be pointless (and slow).
+        # Therefore make the step size dependent on the offset difference.
+        step_size = max(1, int(previous_op_voltage_offset_gap ** 0.5))
+        offset_candidate += step_size
+
+
+def save_results(dev, calibration_file, target_op_temp, channel_name, target_op_voltage, fe_offset):
+    """
+    Saves the calibration results to a file.
+
+    :param dev: the computer board driver class.
+    :param calibration_file: The path to the file where the calibration data will be saved.
+    :param target_op_temp: The target operating temperature in degrees Celsius.
+    :param channel_name: The name of the channel being calibrated.
+    :param target_op_voltage: The target operating voltage in volts.
+    :param fe_offset: The front-end offset value used during calibration.
+    :return: None
+    :sideeffects: Appends a new row of calibration data to the specified file.
+    """
+    temp_measured = dev.get_cold_plate_temp()
+    voltage_measured = dev.get_voltage()
+    # Saving the data
+    with open(calibration_file, "a", newline="") as file:
+        writer = csv.writer(file, delimiter='\t')
+        writer.writerow([
+            f"{target_op_temp:.2f}",
+            f"{temp_measured:.2f}",
+            channel_name,
+            f"{target_op_voltage:.2f}",
+            f"{voltage_measured:.2f}",
+            f"{fe_offset:d}",
+        ])
+
+
+def run(
+        dev: JOLTComputerBoard,
+        temperatures: List[float] = TARGET_OP_TEMPS,
+        channels: List[Channel] = CHANNELS,
+        voltage_range: Tuple[float] = OP_VOLTAGE_RANGE,
+        stop_event: Optional[Event] = None,
+        calibration_file: Optional[Path] = None,
+    ):
+    """
+    Calibration runner for front-end offset vs. front-end output voltage optimization.
+
+    :param dev: the computer board driver class.
+    :param temperatures: a list of operating temperatures, in C.
+    :param channels: a list of channel colors.
+    :param voltage_range: the operating voltage search space, (min, max, step), in V.
+    :param stop_event: a handle to stop the calibration process during a run.
+    :param calibration_file: path to output file (extension: feo.tsv). If None, will use a AppDir as a folder, and naming scheme
+        based on the front-end board serial number and the datetime. During runtime, this filename will prefixed with _.
+        After completion the _ is removed. In this manner, one can differentiate between a passed, a running,
+        or an interrupted or failed run.
+    :sideeffect: a file on disk (see calibration_file).
+    """
+    if calibration_file is None:
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M")
+
+        jolt_sn = dev.get_fe_sn()
+        dirs = AppDirs("Jolt", "Delmic")
+        data_dir = Path(dirs.user_data_dir)
+        data_dir.mkdir(exist_ok=True)
+        calibration_file = data_dir / f"jolt-calibration-{jolt_sn}-{timestamp}.feo.tsv"
+
+    calibration_file_tmp = calibration_file.with_name(f"_{calibration_file.name}")
+
+    # Set max gain and zero offset, which is the ideal setting for imaging
+    await_set_stabilized(dev.set_gain, dev.get_gain, target=100, tolerance=2)
+    await_set_stabilized(dev.set_offset, dev.get_offset, target=0, tolerance=1)
+
+    target_op_voltages = [*arange(*voltage_range), voltage_range[1]]
+
+    with open(calibration_file_tmp, "w", newline="") as file:
+        writer = csv.writer(file, delimiter='\t')
+        writer.writerow(["temperature_target", "temperature", "channel", "voltage_target", "voltage", "fe_offset"])
+
+    total_combinations = len(temperatures) * len(channels) * len(target_op_voltages)
+    current_combination_idx = 0
+    total_runtime = 0
+
+    for target_op_temp in temperatures:
+        logger.info(f"Switching temperature to: {target_op_temp}")
+        await_set_stabilized(dev.set_target_mppc_temp, dev.get_cold_plate_temp, target_op_temp, tolerance=0.1)
+
+        for channel in channels:
+            logger.info(f"Switching channel to: {channel}")
+            await_set(dev.set_channel, dev.get_channel, channel)
+
+            # Per channel, keep track of the offset difference between operating voltages
+            previous_op_voltage_offset_gap = 0
+            for i, target_op_voltage in enumerate(target_op_voltages):
+                start_time = time.time()
+                logger.info(f"Switching operating voltage to: {target_op_voltage}")
+                await_set_stabilized(dev.adjust_voltage, dev.get_voltage, target_op_voltage, tolerance=0.1)
+
+                # For the first operating voltage, we want to do an exhaustive search
+                if i == 0:
+                    fe_offset = find_initial_fe_offset(dev, stop_event)
+
+                    # If user canceled, or if no initial value was found, stop the algorithm.
+                    if fe_offset in [STOP_EVENT_STRING, None]:
+                        return
+
+                # For the subsequent operating voltages, an optimized approach is used.
+                elif i > 0:
+                    previous_fe_offset = fe_offset
+                    fe_offset = find_subsequent_fe_offset(dev, previous_fe_offset, previous_op_voltage_offset_gap, stop_event)
+
+                    if fe_offset == STOP_EVENT_STRING:
+                        return
+
+                    previous_op_voltage_offset_gap = fe_offset - previous_fe_offset
+
+                logger.info(f"Converged: {fe_offset} offset")
+                # Saving results to tsv file on disk
+                save_results(dev, calibration_file_tmp, target_op_temp, channel.name, target_op_voltage, fe_offset)
+
+                # Time estimation logging
+                runtime = time.time() - start_time
+                current_combination_idx += 1
+                total_runtime += runtime
+                seconds_left = total_runtime * (total_combinations / current_combination_idx - 1)
+                hours, minutes, seconds = str(timedelta(seconds=total_runtime)).split(":")
+                logger.info(f"Total runtime: {hours}h {minutes}m {int(float(seconds))}s")
+                hours, minutes, seconds = str(timedelta(seconds=seconds_left)).split(":")
+                logger.info(f"Estimated time left: {hours}h {minutes}m {int(float(seconds))}s")
+
+    # Remove the _ prefix after completion
+    calibration_file_tmp.rename(calibration_file)

--- a/src/jolt/util/math.py
+++ b/src/jolt/util/math.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+'''
+Module containing various math utilities.
+
+Created on 12 March 2025
+@author: Tim Moerkerken
+Copyright © 2025 Tim Moerkerken, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see http://www.gnu.org/licenses/.
+'''
+
+
+import statistics
+from typing import Iterable, List, Optional, Tuple
+
+
+def argmin(iterable: Iterable[float]) -> List:
+    """
+    Returns the indices of the elements in the iterable sorted based on their values.
+
+    :param iterable: An iterable of float values.
+    :return: A list of indices sorted based on the values in the iterable.
+    """
+    iterable = list(iterable)
+    return sorted(range(len(iterable)), key=lambda i: iterable[i])
+
+
+def covariance(x: Iterable[float], y: Iterable[float]) -> float:
+    """
+    Calculates covariance, a measure of the joint variability, between two datasets.
+    TODO: An identical function is introduced in Python 3.10 as part of the statistics library. Remove this function and
+    replace its uses by statistics.covariance once the Python version is upgraded.
+
+    :param x: Dataset x fo size n
+    :param y: Dataset y of size n
+    :return: Covariance between x and y
+    """
+    if len(x) != len(y):
+        raise ValueError("Both lists must have the same length.")
+    if len(x) < 2:
+        raise ValueError("At least two data points are required.")
+
+    mean_x = sum(x) / len(x)
+    mean_y = sum(y) / len(y)
+
+    cov = sum((xi - mean_x) * (yi - mean_y) for xi, yi in zip(x, y)) / (len(x) - 1)
+    return cov
+
+
+def linear_regression(regression_points: List[tuple], slope: Optional[bool] = None) -> Tuple[float]:
+    """
+    Performs linear regression on a set of points.
+
+    :param regression_points: A list of (x, y) points to perform regression on.
+    :param slope: The slope of the line. If not provided, it will be calculated.
+    :return: the linear regression coefficients (slope, intercept)
+    """
+
+    x_values, y_values = zip(*regression_points)
+    mean_x = statistics.mean(x_values)
+    mean_y = statistics.mean(y_values)
+
+    if not slope:
+        # Compute slope (a) if not provided
+        slope = covariance(x_values, y_values) / statistics.variance(x_values)
+
+    # Compute intercept (b)
+    intercept = mean_y - slope * mean_x
+
+    return slope, intercept

--- a/src/jolt/util/measurement.py
+++ b/src/jolt/util/measurement.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+'''
+Module containing methods useful for measurements on the Jolt computer board.
+
+Created on 12 March 2025
+@author: Tim Moerkerken
+Copyright © 2025 Tim Moerkerken, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see http://www.gnu.org/licenses/.
+'''
+
+
+import time
+import logging
+from typing import Callable, List, Union
+
+logger = logging.getLogger(__name__)
+
+# Types to be expected for generic setters and getters
+GenericType = Union[str, int, float, bool]
+
+
+def await_set_stabilized(
+    setter: Callable[[Union[int, float]], None],
+    getter: Callable[[], Union[int, float]],
+    target: float,
+    tolerance: float = 0,
+    repeats: int = 1,
+    interval: float = 0.5,
+    timeout: float = 120,
+) -> Union[int, float]:
+    """
+    Waits until the getter value stabilizes at the target value within a given tolerance.
+
+    :param setter: A function to set the target value.
+    :param getter: A function to get the current value.
+    :param target: The target value to be reached.
+    :param tolerance: The acceptable absolute tolerance for the target value.
+    :param repeats: The number of consecutive readings within tolerance required for stabilization.
+    :param interval: The interval between consecutive readings in seconds.
+    :param timeout: The maximum time to wait for stabilization in seconds.
+    :return: The stabilized value.
+    :sideeffects: Calls the setter and getter functions repeatedly.
+    """
+    n_stable = 0
+    setter(target)
+    start_time = time.time()
+    getter_name = getter.__name__
+    while True:
+        run_time = time.time() - start_time
+        if run_time >= timeout:
+            logger.debug(f"Timed out for {getter_name} to reach {target}, currently {current} within {timeout} s")
+            return current
+        current = getter()
+        logger.debug(f"Waiting for {getter_name} to reach {target:0.3f}, currently {current:0.3f}")
+        in_tolerance = abs(current - target) < tolerance
+        n_stable = n_stable + 1 if in_tolerance else 0
+        if n_stable >= repeats:
+            return current
+        time.sleep(interval)
+
+
+def await_set(
+    setter: Callable[[GenericType], None],
+    getter: Callable[[], GenericType],
+    target: GenericType,
+    interval: float = 0.1,
+    timeout: float = 30,
+) -> GenericType:
+    """
+    Waits until the getter value reaches the target value or the timeout is reached.
+
+    :param setter: A function to set the target value.
+    :param getter: A function to get the current value.
+    :param target: The target value to be reached.
+    :param interval: The interval between consecutive readings in seconds.
+    :param timeout: The maximum time to wait for the target value in seconds.
+    :return: The final value after waiting.
+    :sideeffects: Calls the setter and getter functions repeatedly.
+    """
+    setter(target)
+    run_time = 0
+    start_time = time.time()
+    while True:
+        current = getter()
+        run_time = time.time() - start_time
+        if current == target or run_time >= timeout:
+            break
+        time.sleep(interval)
+    return current
+
+
+def repeated_get(
+    getter: Callable[[], GenericType],
+    repeats: int,
+    interval: float = 1,
+) -> List[GenericType]:
+    """
+    Calls the getter function repeatedly at specified intervals and returns the results.
+
+    :param getter: A function to get the current value.
+    :param repeats: The number of times to call the getter function.
+    :param interval: The interval between consecutive calls in seconds.
+    :return: A list of values obtained from the getter function.
+    :sideeffects: Calls the getter function repeatedly.
+    """
+    results = []
+    getter_name = getter.__name__
+    logger.debug(f"Calling {getter_name} at interval {interval} s, {repeats} repeats")
+    for i in range(repeats):
+        results.append(getter())
+        time.sleep(interval)
+
+    return results


### PR DESCRIPTION
## This PR adds

- Front-end offset calibration algorithm.
- UI for starting/stopping front-end offset calibration.
- Automatic loading of front-end offset calibration file when present.
- Using best front-end offset from calibration file when settings are changed.
- Controls for front-end offset and output.

## Misc. fixes
- Improved startup process when opening the app, by fixing an EOT character bug in the serial response.
- Better usability of operating voltage control by splitting the input field and the current value into two elements.
- Operating voltage on the hardware will now be closer to the value set by the user, by adding an iterative
  voltage setter to the driver.
- Text input fields are now easier to use, by better utilizing event properties.